### PR TITLE
User gn endpoint

### DIFF
--- a/app/controllers/api/v1/users/game_nights_controller.rb
+++ b/app/controllers/api/v1/users/game_nights_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Users
+      class GameNightsController < ApplicationController
+        def index
+          user = User.find(params[:user_id])
+          render json: GameNightSerializer.new(user.get_game_nights)
+        end
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,9 @@ class User < ApplicationRecord
     user.save
     user
   end
+
+  def get_game_nights
+    attendee_gns = GameNight.joins(:invitations).where(invitations: { user_id: id })
+    attendee_gns + game_nights
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       # User crud
       resources :users do
         get :friends, to: 'users/friends#index'
+        get :game_nights, to: 'users/game_nights#index'
       end
 
       # Games crud

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,4 +18,48 @@ describe User, type: :model do
     it { is_expected.to have_many(:buds).through :friends }
     it { is_expected.to have_many :invitations }
   end
+
+  describe 'instance methods' do
+    it '#get_game_nights' do
+      user_1 = create(:user)
+      user_2 = create(:user)
+
+      Friend.create(user_id: user_1.id, bud_id: user_2.id)
+      Friend.create(user_id: user_2.id, bud_id: user_1.id)
+
+      game_1 = create :game
+      game_2 = create :game
+
+      UserGame.create(user_id: user_1.id, game_id: game_1.id)
+      UserGame.create(user_id: user_2.id, game_id: game_2.id)
+
+      game_night = GameNight.create!(
+        user_id: user_1.id,
+        name: 'Friday Fun Night',
+        date: '1/15/2021',
+        number_of_games: 2
+      )
+
+      Invitation.create!(
+        status: 'pending',
+        user_id: user_2.id,
+        game_night_id: game_night.id
+      )
+
+      game_night_2 = GameNight.create!(
+        user_id: user_2.id,
+        name: 'Thursday Fun Night',
+        date: '2/15/2021',
+        number_of_games: 2
+      )
+
+      Invitation.create!(
+        status: 'pending',
+        user_id: user_1.id,
+        game_night_id: game_night_2.id
+      )
+
+      expect(user_1.get_game_nights.sort).to eq([game_night, game_night_2].sort)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,7 +54,7 @@ describe User, type: :model do
       )
 
       Invitation.create!(
-        status: 'pending',
+        status: 'declined',
         user_id: user_1.id,
         game_night_id: game_night_2.id
       )

--- a/spec/requests/api/v1/users/game_nights/request_spec.rb
+++ b/spec/requests/api/v1/users/game_nights/request_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'api/v1/users/game_nights/request', type: :request do
         user_1 = create :user
         user_2 = create :user
 
-        game_night = GameNight.create!(
+        GameNight.create!(
           user_id: user_2.id,
           name: 'Friday Fun Night',
           date: '1/15/2021',
@@ -79,7 +79,7 @@ RSpec.describe 'api/v1/users/game_nights/request', type: :request do
       it 'returns a 404' do
         get api_v1_user_game_nights_path(3)
 
-        json_body = JSON.parse(response.body, symbolize_names: true)
+        JSON.parse(response.body, symbolize_names: true)
 
         expect(response.status).to eq(404)
       end

--- a/spec/requests/api/v1/users/game_nights/request_spec.rb
+++ b/spec/requests/api/v1/users/game_nights/request_spec.rb
@@ -48,20 +48,40 @@ RSpec.describe 'api/v1/users/game_nights/request', type: :request do
 
         json_body = JSON.parse(response.body, symbolize_names: true)
 
-        expect(json_body[:message]).to eq('success')
-        require "pry"; binding.pry
+        expect(response.status).to eq(200)
+        expect(json_body[:data].count).to eq(2)
+        user_game_nights_response_checker(json_body, game_night_2)
       end
     end
 
     context 'when there are no games' do
-      xit 'the response is empty' do
+      it 'the response is empty' do
+        user_1 = create :user
+        user_2 = create :user
 
+        game_night = GameNight.create!(
+          user_id: user_2.id,
+          name: 'Friday Fun Night',
+          date: '1/15/2021',
+          number_of_games: 2
+        )
+
+        get api_v1_user_game_nights_path(user_1)
+
+        json_body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response.status).to eq(200)
+        expect(json_body[:data].count).to eq(0)
       end
     end
 
     context 'when the user does not exist' do
-      xit 'returns a 404' do
+      it 'returns a 404' do
+        get api_v1_user_game_nights_path(3)
 
+        json_body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response.status).to eq(404)
       end
     end
   end

--- a/spec/requests/api/v1/users/game_nights/request_spec.rb
+++ b/spec/requests/api/v1/users/game_nights/request_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'api/v1/users/game_nights/request', type: :request do
+  describe 'GET /users/:id/game_nights' do
+    context 'when the user has game nights as a host or attendee' do
+      it 'returns a list of the game nights' do
+        user_1 = create :user
+        user_2 = create :user
+
+        Friend.create(user_id: user_1.id, bud_id: user_2.id)
+        Friend.create(user_id: user_2.id, bud_id: user_1.id)
+
+        game_1 = create :game
+        game_2 = create :game
+
+        UserGame.create(user_id: user_1.id, game_id: game_1.id)
+        UserGame.create(user_id: user_2.id, game_id: game_2.id)
+
+        game_night = GameNight.create!(
+          user_id: user_1.id,
+          name: 'Friday Fun Night',
+          date: '1/15/2021',
+          number_of_games: 2
+        )
+
+        Invitation.create!(
+          status: 'pending',
+          user_id: user_2.id,
+          game_night_id: game_night.id
+        )
+
+        game_night_2 = GameNight.create!(
+          user_id: user_2.id,
+          name: 'Thursday Fun Night',
+          date: '2/15/2021',
+          number_of_games: 2
+        )
+
+        Invitation.create!(
+          status: 'pending',
+          user_id: user_1.id,
+          game_night_id: game_night_2.id
+        )
+
+        get api_v1_user_game_nights_path(user_1)
+
+        json_body = JSON.parse(response.body, symbolize_names: true)
+
+        expect(json_body[:message]).to eq('success')
+        require "pry"; binding.pry
+      end
+    end
+
+    context 'when there are no games' do
+      xit 'the response is empty' do
+
+      end
+    end
+
+    context 'when the user does not exist' do
+      xit 'returns a 404' do
+
+      end
+    end
+  end
+end

--- a/spec/response_checkers.rb
+++ b/spec/response_checkers.rb
@@ -43,4 +43,33 @@ module ResponseCheckers
     expect(user_response[:data][:attributes]).to have_key(:game_nights)
     expect(user_response[:data][:attributes][:game_nights]).to be_a(Array)
   end
+
+  def user_game_nights_response_checker(user_gn_response, gn_1)
+    expect(user_gn_response).to be_a(Hash)
+
+    expect(user_gn_response[:data]).to be_a(Array)
+
+    expect(user_gn_response[:data].first).to have_key(:id)
+    expect(user_gn_response[:data].first[:id]).to be_a(String)
+    expect(user_gn_response[:data].first[:id].to_i).to eq(gn_1.id)
+
+    expect(user_gn_response[:data].first).to have_key(:type)
+    expect(user_gn_response[:data].first[:type]).to be_a(String)
+    expect(user_gn_response[:data].first[:type]).to eq('game_night')
+
+    expect(user_gn_response[:data].first).to have_key(:attributes)
+    expect(user_gn_response[:data].first[:attributes]).to be_a(Hash)
+
+    expect(user_gn_response[:data].first[:attributes]).to have_key(:name)
+    expect(user_gn_response[:data].first[:attributes][:name]).to be_a(String)
+    expect(user_gn_response[:data].first[:attributes][:name]).to eq(gn_1.name)
+
+    expect(user_gn_response[:data].first[:attributes]).to have_key(:date)
+    expect(user_gn_response[:data].first[:attributes][:date]).to be_a(String)
+    expect(user_gn_response[:data].first[:attributes][:date]).to eq(gn_1.date)
+
+    expect(user_gn_response[:data].first[:attributes]).to have_key(:number_of_games)
+    expect(user_gn_response[:data].first[:attributes][:number_of_games]).to be_a(Integer)
+    expect(user_gn_response[:data].first[:attributes][:number_of_games]).to eq(gn_1.number_of_games)
+  end
 end


### PR DESCRIPTION
### Description

Adds an endpoint to return the game nights of a specific user. 

### Closes issue(s)

#40 

### Testing

Sad path and regular tests, uses response checkers!

### Screenshots

### Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

### Checklist
- [X] I have written tests for this code (happy & sad)
- [ ] I have updated the Readme
- [X] I ran rubocop and fixed issues
- [X] I ran full test suite - all tests passing 

### Other comments
1. Does not take into account pending or declined on invitations. Need to add that in once we figure that out. 
2. Returns too much data about the game night, need to fix that. Maybe we should make a new serializer for this? Thoughts?